### PR TITLE
Fix Private URLs of aggregated calendars

### DIFF
--- a/authBackendDokuwiki.php
+++ b/authBackendDokuwiki.php
@@ -13,8 +13,8 @@ class DokuWikiSabreAuthBackend extends Sabre\DAV\Auth\Backend\AbstractBasic
         global $auth;
         global $conf;
         $ret = $auth->checkPass($username, $password);
-        dbglog('---- DAVCAL authBackendDokuwiki.php init');
-        dbglog('checkPass called for username '.$username.' with result '.$ret);
+        \dokuwiki\Logger::debug('DAVCAL', 'Auth backend initialized', __FILE__, __LINE__);
+        \dokuwiki\Logger::debug('DAVCAL', 'checkPass called for username '.$username.' with result '.$ret, __FILE__, __LINE__);
         return $ret;
     }
 }

--- a/calendarBackendDokuwiki.php
+++ b/calendarBackendDokuwiki.php
@@ -92,6 +92,13 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
         foreach($idInfo as $id => $data)
         {
             $row = $this->hlp->getCalendarSettings($id);
+
+            // Skip this calendar if settings couldn't be retrieved
+            if (!$row) {
+                \dokuwiki\Logger::debug('DAVCAL', 'Skipping calendar '.$id.' - settings not found', __FILE__, __LINE__);
+                continue;
+            }
+
             $components = array();
             if ($row['components']) 
             {
@@ -107,7 +114,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
                 '{' . CalDAV\Plugin::NS_CALDAV . '}supported-calendar-component-set' => new CalDAV\Xml\Property\SupportedCalendarComponentSet($components),
                 //'{' . CalDAV\Plugin::NS_CALDAV . '}schedule-calendar-transp'         => new CalDAV\Xml\Property\ScheduleCalendarTransp($row['transparent'] ? 'transparent' : 'opaque'),
             );
-            if($idInfo[$row['id']]['readonly'] === true)
+            if(isset($idInfo[$id]['readonly']) && $idInfo[$id]['readonly'] === true)
                 $calendar['{http://sabredav.org/ns}read-only'] = '1';
 
 

--- a/calendarBackendDokuwiki.php
+++ b/calendarBackendDokuwiki.php
@@ -78,7 +78,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getCalendarsForUser($principalUri) 
     {
-        dbglog('calendarBackendDokuwiki::getCalendarsForUser: '.$principalUri);
+        \dokuwiki\Logger::debug('DAVCAL', 'getCalendarsForUser called for: '.$principalUri, __FILE__, __LINE__);
         $fields = array_values($this->propertyMap);
         $fields[] = 'id';
         $fields[] = 'uri';
@@ -119,7 +119,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
             $calendars[] = $calendar;
 
         }
-        dbglog($calendars);
+        \dokuwiki\Logger::debug('DAVCAL', 'Calendars returned: '.count($calendars), __FILE__, __LINE__);
         return $calendars;
 
     }
@@ -137,7 +137,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function createCalendar($principalUri, $calendarUri, array $properties) 
     {
-        dbglog('calendarBackendDokuwiki::createCalendar called, returning false');
+        \dokuwiki\Logger::debug('DAVCAL', 'createCalendar called, returning false', __FILE__, __LINE__);
         return false;
     }
 
@@ -159,7 +159,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch) 
     {
-        dbglog('calendarBackendDokuwiki::updateCalendar for calendarId '.$calendarId);
+        \dokuwiki\Logger::debug('DAVCAL', 'updateCalendar for calendarId '.$calendarId, __FILE__, __LINE__);
         $supportedProperties = array_keys($this->propertyMap);
 
         $propPatch->handle($supportedProperties, function($mutations) use ($calendarId) 
@@ -170,15 +170,15 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
                 switch ($propertyName) 
                 {
                     case '{DAV:}displayname' :
-                        dbglog('updateCalendarName');
+                        \dokuwiki\Logger::debug('DAVCAL', 'updateCalendarName', __FILE__, __LINE__);
                         $this->hlp->updateCalendarName($calendarId, $propertyValue);
                         break;
                     case '{urn:ietf:params:xml:ns:caldav}calendar-description':
-                        dbglog('updateCalendarDescription');
+                        \dokuwiki\Logger::debug('DAVCAL', 'updateCalendarDescription', __FILE__, __LINE__);
                         $this->hlp->updateCalendarDescription($calendarId, $propertyValue);
                         break;
                     case '{urn:ietf:params:xml:ns:caldav}calendar-timezone':
-                        dbglog('updateCalendarTimezone');
+                        \dokuwiki\Logger::debug('DAVCAL', 'updateCalendarTimezone', __FILE__, __LINE__);
                         $this->hlp->updateCalendarTimezone($calendarId, $propertyValue);
                         break;
                     default :
@@ -200,7 +200,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function deleteCalendar($calendarId) 
     {
-        dbglog('calendarBackendDokuwiki::deleteCalendar called, returning false');
+        \dokuwiki\Logger::debug('DAVCAL', 'deleteCalendar called, returning false', __FILE__, __LINE__);
         return;
     }
 
@@ -237,7 +237,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getCalendarObjects($calendarId) 
     {
-        dbglog('calendarBackendDokuwiki::getCalendarObjects for calendarId '.$calendarId);
+        \dokuwiki\Logger::debug('DAVCAL', 'getCalendarObjects for calendarId '.$calendarId, __FILE__, __LINE__);
         $arr = $this->hlp->getCalendarObjects($calendarId);
         $result = array();
         foreach ($arr as $row) 
@@ -252,7 +252,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
                 'component'    => strtolower($row['componenttype']),
             );
         }
-        dbglog($result);
+        \dokuwiki\Logger::debug('DAVCAL', 'Calendar objects returned: '.count($result), __FILE__, __LINE__);
         return $result;
 
     }
@@ -275,9 +275,9 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getCalendarObject($calendarId, $objectUri) 
     {
-        dbglog('calendarBackendDokuwiki::getCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri);
+        \dokuwiki\Logger::debug('DAVCAL', 'getCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri, __FILE__, __LINE__);
         $row = $this->hlp->getCalendarObjectByUri($calendarId, $objectUri);
-        dbglog($row);
+        \dokuwiki\Logger::debug('DAVCAL', 'Calendar object row: '.($row ? 'found' : 'not found'), __FILE__, __LINE__);
         if (!$row) 
             return null;
 
@@ -308,8 +308,8 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getMultipleCalendarObjects($calendarId, array $uris) 
     {
-        dbglog('calendarBackendDokuwiki::getMultipleCalendarObjects for calendarId '.$calendarId);
-        dbglog($uris);
+        \dokuwiki\Logger::debug('DAVCAL', 'getMultipleCalendarObjects for calendarId '.$calendarId, __FILE__, __LINE__);
+        \dokuwiki\Logger::debug('DAVCAL', 'URIs requested: '.count($uris), __FILE__, __LINE__);
         $arr = $this->hlp->getMultipleCalendarObjectsByUri($calendarId, $uris);
 
         $result = array();
@@ -328,7 +328,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
             );
 
         }
-        dbglog($result);
+        \dokuwiki\Logger::debug('DAVCAL', 'Multiple calendar objects returned: '.count($result), __FILE__, __LINE__);
         return $result;
 
     }
@@ -354,10 +354,10 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function createCalendarObject($calendarId, $objectUri, $calendarData) 
     {
-        dbglog('calendarBackendDokuwiki::createCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri);
-        dbglog($calendarData);
+        \dokuwiki\Logger::debug('DAVCAL', 'createCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri, __FILE__, __LINE__);
+        \dokuwiki\Logger::debug('DAVCAL', 'Calendar data length: '.strlen($calendarData), __FILE__, __LINE__);
         $etag = $this->hlp->addCalendarEntryToCalendarByICS($calendarId, $objectUri, $calendarData);
-        dbglog($etag);
+        \dokuwiki\Logger::debug('DAVCAL', 'ETag generated: '.$etag, __FILE__, __LINE__);
         
         return '"' . $etag . '"';
     }
@@ -382,10 +382,10 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function updateCalendarObject($calendarId, $objectUri, $calendarData) 
     {
-        dbglog('calendarBackendDokuwiki::updateCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri);
-        dbglog($calendarData);
+        \dokuwiki\Logger::debug('DAVCAL', 'updateCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri, __FILE__, __LINE__);
+        \dokuwiki\Logger::debug('DAVCAL', 'Calendar data length: '.strlen($calendarData), __FILE__, __LINE__);
         $etag = $this->hlp->editCalendarEntryToCalendarByICS($calendarId, $objectUri, $calendarData);
-        dbglog($etag);
+        \dokuwiki\Logger::debug('DAVCAL', 'ETag generated: '.$etag, __FILE__, __LINE__);
         return '"' . $etag. '"';
 
     }
@@ -403,7 +403,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function deleteCalendarObject($calendarId, $objectUri) 
     {
-        dbglog('calendarBackendDokuwiki::deleteCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri);
+        \dokuwiki\Logger::debug('DAVCAL', 'deleteCalendarObject for calendarId '.$calendarId.' and objectUri '.$objectUri, __FILE__, __LINE__);
         $this->hlp->deleteCalendarEntryForCalendarByUri($calendarId, $objectUri);
 
     }
@@ -462,10 +462,10 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function calendarQuery($calendarId, array $filters) 
     {
-        dbglog('calendarBackendDokuwiki::calendarQuery for calendarId '.$calendarId);
-        dbglog($filters);
+        \dokuwiki\Logger::debug('DAVCAL', 'calendarQuery for calendarId '.$calendarId, __FILE__, __LINE__);
+        \dokuwiki\Logger::debug('DAVCAL', 'Filters count: '.count($filters), __FILE__, __LINE__);
         $result = $this->hlp->calendarQuery($calendarId, $filters);
-        dbglog($result);
+        \dokuwiki\Logger::debug('DAVCAL', 'Query results: '.count($result), __FILE__, __LINE__);
         return $result;
     }
 
@@ -490,7 +490,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getCalendarObjectByUID($principalUri, $uid) 
     {
-        dbglog('calendarBackendDokuwiki::getCalendarObjectByUID for principalUri '.$principalUri.' and uid '.$uid);
+        \dokuwiki\Logger::debug('DAVCAL', 'getCalendarObjectByUID for principalUri '.$principalUri.' and uid '.$uid, __FILE__, __LINE__);
         $calids = array_keys($this->hlp->getCalendarIsForUser($principalUri));
         $event = $this->hlp->getEventWithUid($uid);
         
@@ -560,9 +560,9 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getChangesForCalendar($calendarId, $syncToken, $syncLevel, $limit = null) 
     {
-        dbglog('calendarBackendDokuwiki::getChangesForCalendar for calendarId '.$calendarId.' and syncToken '.$syncToken.' and syncLevel '.$syncLevel);
+        \dokuwiki\Logger::debug('DAVCAL', 'getChangesForCalendar for calendarId '.$calendarId.' and syncToken '.$syncToken.' and syncLevel '.$syncLevel, __FILE__, __LINE__);
         $result = $this->hlp->getChangesForCalendar($calendarId, $syncToken, $syncLevel, $limit);
-        dbglog($result);
+        \dokuwiki\Logger::debug('DAVCAL', 'Changes result: '.($result ? 'found' : 'not found'), __FILE__, __LINE__);
         return $result;
     }
 
@@ -599,7 +599,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getSubscriptionsForUser($principalUri) 
     {
-        dbglog('calendarBackendDokuwiki::getSubscriptionsForUser with principalUri '.$principalUri.', returning empty array()');
+        \dokuwiki\Logger::debug('DAVCAL', 'getSubscriptionsForUser with principalUri '.$principalUri.', returning empty array()', __FILE__, __LINE__);
         return array();
 
     }
@@ -617,7 +617,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function createSubscription($principalUri, $uri, array $properties) 
     {
-        dbglog('calendarBackendDokuwiki::createSubscription for principalUri '.$principalUri.' and uri '.$uri.', returning null');
+        \dokuwiki\Logger::debug('DAVCAL', 'createSubscription for principalUri '.$principalUri.' and uri '.$uri.', returning null', __FILE__, __LINE__);
         return null;
 
     }
@@ -640,7 +640,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function updateSubscription($subscriptionId, DAV\PropPatch $propPatch) 
     {
-        dbglog('calendarBackendDokuwiki::updateSubscription with subscriptionId '.$subscriptionId.', returning false');
+        \dokuwiki\Logger::debug('DAVCAL', 'updateSubscription with subscriptionId '.$subscriptionId.', returning false', __FILE__, __LINE__);
         return;
     }
 
@@ -652,7 +652,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function deleteSubscription($subscriptionId) 
     {
-        dbglog('calendarBackendDokuwiki::deleteSubscription with subscriptionId '.$subscriptionId.', returning');
+        \dokuwiki\Logger::debug('DAVCAL', 'deleteSubscription with subscriptionId '.$subscriptionId.', returning', __FILE__, __LINE__);
         return;
 
     }
@@ -675,7 +675,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getSchedulingObject($principalUri, $objectUri) 
     {
-        dbglog('calendarBackendDokuwiki::getSchedulingObject with principalUri '.$principalUri.' and objectUri '.$objectUri.', returning null');
+        \dokuwiki\Logger::debug('DAVCAL', 'getSchedulingObject with principalUri '.$principalUri.' and objectUri '.$objectUri.', returning null', __FILE__, __LINE__);
         return null;
 
     }
@@ -693,7 +693,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function getSchedulingObjects($principalUri) 
     {
-        dbglog('calendarBackendDokuwiki::getSchedulingObjects for principalUri '.$principalUri.', returning null');
+        \dokuwiki\Logger::debug('DAVCAL', 'getSchedulingObjects for principalUri '.$principalUri.', returning null', __FILE__, __LINE__);
         return null;
 
     }
@@ -707,7 +707,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function deleteSchedulingObject($principalUri, $objectUri) 
     {
-        dbglog('calendarBackendDokuwiki::deleteSchedulingObject for principalUri '.$principalUri.' and objectUri '.$objectUri.', returning');
+        \dokuwiki\Logger::debug('DAVCAL', 'deleteSchedulingObject for principalUri '.$principalUri.' and objectUri '.$objectUri.', returning', __FILE__, __LINE__);
         return;
     }
 
@@ -721,7 +721,7 @@ class DokuWikiSabreCalendarBackend extends \Sabre\CalDAV\Backend\AbstractBackend
      */
     function createSchedulingObject($principalUri, $objectUri, $objectData) 
     {
-        dbglog('calendarBackendDokuwiki::createSchedulingObject with principalUri '.$principalUri.' and objectUri '.$objectUri.', returning');
+        \dokuwiki\Logger::debug('DAVCAL', 'createSchedulingObject with principalUri '.$principalUri.' and objectUri '.$objectUri.', returning', __FILE__, __LINE__);
         return;
 
     }

--- a/calendarserver.php
+++ b/calendarserver.php
@@ -14,14 +14,14 @@ session_write_close(); //close session
 
 global $conf;
 
-dbglog('---- DAVCAL calendarserver.php init');
+\dokuwiki\Logger::debug('DAVCAL', 'Calendar server initialized', __FILE__, __LINE__);
 
 $hlp = null;
 $hlp =& plugin_load('helper', 'davcal');
 
 if(is_null($hlp))
 {
-    dbglog('Error loading helper plugin');
+    \dokuwiki\Logger::error('DAVCAL', 'Error loading helper plugin', __FILE__, __LINE__);
     die('Error loading helper plugin');
 }
 
@@ -29,13 +29,13 @@ $baseUri = DOKU_BASE.'lib/plugins/davcal/'.basename(__FILE__).'/';
 
 if($hlp->getConfig('disable_sync') === 1)
 {
-    dbglog('Synchronisation is disabled');
+    \dokuwiki\Logger::debug('DAVCAL', 'Synchronisation is disabled', __FILE__, __LINE__);
     die('Synchronisation is disabled');
 }
 
 //Mapping PHP errors to exceptions
 function exception_error_handler($errno, $errstr, $errfile, $errline) {
-    dbglog('Exception occured: '.$errstr);
+    \dokuwiki\Logger::error('DAVCAL', 'Exception occurred: '.$errstr, __FILE__, __LINE__);
     throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
 //set_error_handler("exception_error_handler");
@@ -90,6 +90,6 @@ $server->addPlugin(new Sabre\DAV\Sync\Plugin());
 $browser = new Sabre\DAV\Browser\Plugin();
 $server->addPlugin($browser);
 
-dbglog('$server->exec()');
+\dokuwiki\Logger::debug('DAVCAL', 'Server execution started', __FILE__, __LINE__);
 // And off we go!
 $server->exec();

--- a/helper.php
+++ b/helper.php
@@ -17,7 +17,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
     * Constructor to load the configuration and the SQLite plugin
     */
   public function __construct() {
-    dbglog('---- DAVCAL helper.php init');
+    \dokuwiki\Logger::debug('DAVCAL', 'Helper initialized', __FILE__, __LINE__);
   }
 
   /** Establish and initialize the database if not already done
@@ -30,14 +30,14 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
         $this->sqlite = plugin_load('helper', 'sqlite');
         if(!$this->sqlite)
         {
-            dbglog('This plugin requires the sqlite plugin. Please install it.');
+            \dokuwiki\Logger::error('DAVCAL', 'This plugin requires the sqlite plugin. Please install it.', __FILE__, __LINE__);
             msg('This plugin requires the sqlite plugin. Please install it.', -1);
             return false;
         }
         if(!$this->sqlite->init('davcal', DOKU_PLUGIN.'davcal/db/'))
         {
             $this->sqlite = null;
-            dbglog('Error initialising the SQLite DB for DAVCal');
+            \dokuwiki\Logger::error('DAVCAL', 'Error initialising the SQLite DB for DAVCal', __FILE__, __LINE__);
             return false;
         }
       }
@@ -1899,7 +1899,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
    */
   public function calendarQuery($calendarId, $filters)
   {
-    dbglog('davcal::helper::calendarQuery');
+    \dokuwiki\Logger::debug('DAVCAL', 'Calendar query executed', __FILE__, __LINE__);
     $componentType = null;
     $requirePostFilter = true;
     $timeRange = null;

--- a/helper.php
+++ b/helper.php
@@ -1528,11 +1528,11 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
    */
   public function getSyncUrlForPage($id, $user = null)
   {
-      if(is_null($userid))
+      if(is_null($user))
       {
         if(isset($_SERVER['REMOTE_USER']) && !is_null($_SERVER['REMOTE_USER']))
         {
-          $userid = $_SERVER['REMOTE_USER'];
+          $user = $_SERVER['REMOTE_USER'];
         }
         else
         {

--- a/helper.php
+++ b/helper.php
@@ -17,7 +17,6 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
     * Constructor to load the configuration and the SQLite plugin
     */
   public function __construct() {
-    \dokuwiki\Logger::debug('DAVCAL', 'Helper initialized', __FILE__, __LINE__);
   }
 
   /** Establish and initialize the database if not already done

--- a/helper.php
+++ b/helper.php
@@ -872,7 +872,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
       $sqlite = $this->getDB();
       if(!$sqlite)
         return false;
-      $query = "SELECT id, principaluri, calendarcolor, displayname, uri, description, components, transparent, synctoken, disabled FROM calendars WHERE id= ? ";
+      $query = "SELECT id, principaluri, calendarcolor, displayname, uri, description, components, transparent, synctoken, disabled, timezone FROM calendars WHERE id= ? ";
       $row = $sqlite->queryRecord($query, [$calid]);
       return $row;
   }

--- a/helper.php
+++ b/helper.php
@@ -1684,8 +1684,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
 
       // Find the aggregated calendar ID from the URL
       $query = "SELECT calid FROM calendartoprivateurlmapping WHERE url = ?";
-      $res = $sqlite->query($query, $icsFile);
-      $row = $sqlite->res2row($res);
+      $row = $sqlite->queryRecord($query, [$icsFile]);
 
       if(!isset($row['calid']))
         return false;
@@ -1694,8 +1693,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
 
       // Get the page ID for this aggregated calendar
       $query = "SELECT page FROM pagetocalendarmapping WHERE calid = ?";
-      $res = $sqlite->query($query, $aggregateId);
-      $row = $sqlite->res2row($res);
+      $row = $sqlite->queryRecord($query, [$aggregateId]);
 
       if(!isset($row['page']))
         return false;
@@ -1925,8 +1923,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
         $values[] = $timeRange['end']->getTimeStamp();
     }
 
-    $res = $sqlite->query($query, $values);
-    $arr = $sqlite->res2arr($res);
+    $arr = $sqlite->queryAll($query, $values);
 
     $result = array();
     foreach($arr as $row)
@@ -2006,11 +2003,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
           if ($limit > 0) $query .= " LIMIT " . (int)$limit;
 
           // Fetching all changes
-          $res = $sqlite->query($query, $syncToken, $currentToken, $calid);
-          if($res === false)
-              return null;
-
-          $arr = $sqlite->res2arr($res);
+          $arr = $sqlite->queryAll($query, array($syncToken, $currentToken, $calid));
           $changes = array();
 
           // This loop ensures that any duplicates are overwritten, only the
@@ -2041,8 +2034,7 @@ class helper_plugin_davcal extends DokuWiki_Plugin {
       {
           // No synctoken supplied, this is the initial sync.
           $query = "SELECT uri FROM calendarobjects WHERE calendarid = ?";
-          $res = $sqlite->query($query);
-          $arr = $sqlite->res2arr($res);
+          $arr = $sqlite->queryAll($query, array($calid));
 
           $result['added'] = $arr;
       }

--- a/ics.php
+++ b/ics.php
@@ -11,7 +11,7 @@ session_write_close(); //close session
 
 global $conf;
 if($conf['allowdebug'])
-    dbglog('---- DAVCAL ics.php init');
+    \dokuwiki\Logger::debug('DAVCAL', 'ICS server initialized', __FILE__, __LINE__);
 
 $path = explode('/', $_SERVER['REQUEST_URI']);
 $icsFile = end($path);
@@ -23,14 +23,14 @@ $hlp =& plugin_load('helper', 'davcal');
 if(is_null($hlp))
 {
     if($conf['allowdebug'])
-        dbglog('Error loading helper plugin');
+        \dokuwiki\Logger::error('DAVCAL', 'Error loading helper plugin', __FILE__, __LINE__);
     die('Error loading helper plugin');
 }
 
 if($hlp->getConfig('disable_ics') === 1)
 {
     if($conf['allowdebug'])
-        dbglog('ICS synchronisation is disabled');
+        \dokuwiki\Logger::debug('DAVCAL', 'ICS synchronisation is disabled', __FILE__, __LINE__);
     die("ICS synchronisation is disabled");
 }
 
@@ -42,7 +42,7 @@ if(strpos($icsFile, 'dokuwiki-aggregated-') === 0)
     if($stream === false)
     {
         if($conf['allowdebug'])
-            dbglog('No aggregated calendar with this name known: '.$icsFile);
+            \dokuwiki\Logger::error('DAVCAL', 'No aggregated calendar with this name known: '.$icsFile, __FILE__, __LINE__);
         die("No aggregated calendar with this name known.");
     }
 }
@@ -55,7 +55,7 @@ else
     if($calid === false)
     {
         if($conf['allowdebug'])
-            dbglog('No calendar with this name known: '.$icsFile);
+            \dokuwiki\Logger::error('DAVCAL', 'No calendar with this name known: '.$icsFile, __FILE__, __LINE__);
         die("No calendar with this name known.");
     }
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base	davcal
-author  Andreas Boehler
+author  Andreas Boehler, Scott Lee Chua
 email   dev@aboehler.at
-date    2022-08-04
+date    2025-07-07
 name    Calendar PlugIn with CalDAV sharing support
 desc    Create one calendar per page and share/subscribe via CalDAV
 url     http://www.dokuwiki.org/plugin:davcal

--- a/syntax/calendar.php
+++ b/syntax/calendar.php
@@ -78,7 +78,13 @@ class syntax_plugin_davcal_calendar extends DokuWiki_Syntax_Plugin {
 
         foreach($options as $option)
         {
-            list($key, $val) = explode('=', $option);
+            $option = trim($option);
+            if(empty($option)) continue;
+            
+            $parts = explode('=', $option, 2);
+            if(count($parts) < 2) continue;
+            
+            list($key, $val) = $parts;
             $key = strtolower(trim($key));
             $val = trim($val);
             switch($key)
@@ -101,7 +107,13 @@ class syntax_plugin_davcal_calendar extends DokuWiki_Syntax_Plugin {
                     $fcoptions = explode(';', $val);
                     foreach($fcoptions as $opt)
                     {
-                        list($o, $v) = explode(':', $opt, 2);
+                        $opt = trim($opt);
+                        if(empty($opt)) continue;
+                        
+                        $parts = explode(':', $opt, 2);
+                        if(count($parts) < 2) continue;
+                        
+                        list($o, $v) = $parts;
                         $data['fcoptions'][$o] = $v;
                     }
                 break;

--- a/syntax/calendar.php
+++ b/syntax/calendar.php
@@ -157,7 +157,11 @@ class syntax_plugin_davcal_calendar extends DokuWiki_Syntax_Plugin {
                 {
                     $calid = $this->hlp->getCalendarIdForPage($ID);
                     $settings = $this->hlp->getCalendarSettings($calid);
-                    $color = $settings['calendarcolor'];
+                    if (is_array($settings) && isset($settings['calendarcolor'])) {
+                        $color = $settings['calendarcolor'];
+                    } else {
+                        $color = '#3a87ad'; // fallback color if settings are missing
+                    }
                     $data['id'][$id] = $color;
                 }
             }


### PR DESCRIPTION
Previously, the Private (read-only) URLs of aggregated calendars were returning empty and/or malformed calendars, even though the Private URLs of single calendars were functioning perfectly.

This PR handles the special case of aggregate calendars. Each unique combination of (page + composition of calendars) is assigned its own calendar ID.

## Tests

This PR works on my local Docker installation of DokuWiki — here's an aggregate calendar composed of 3 calendars in Dokuwiki:

![Screenshot 2025-07-07 at 18 44 43](https://github.com/user-attachments/assets/b3eac4e3-eb36-4b00-a61e-6b320cf31bf1)

and here's my local Mac Calendar subscribed to the Private URL, showing events from all 3 calendars:

![Screenshot 2025-07-07 at 18 44 47](https://github.com/user-attachments/assets/5de70dee-38c9-4121-9e49-4ca78f5699de)

## Notes
This PR does not change the fact that aggregated calendars do not show up in CalDAV. I think this is ok, as someone signing in to CalDAV can reconstruct the aggregated calendars to their liking anyway.